### PR TITLE
Adding gasPrice parametr to fix errors with contract creation.

### DIFF
--- a/docs/build-on-morph/practical-examples/1-deploy-contract-on-morph.md
+++ b/docs/build-on-morph/practical-examples/1-deploy-contract-on-morph.md
@@ -67,6 +67,7 @@ yarn test
       url: process.env.MORPH_TESTNET_URL || "",
       accounts:
         process.env.PRIVATE_KEY !== undefined ? [process.env.PRIVATE_KEY] : [],
+      gasPrice: 2000000000
     }
    ```
 Then run the following command to deploy the contract on the Morph Sepolia Testnet. This will run the deployment script that set the initialing parameters, you can edit the script in scripts/deploy.ts


### PR DESCRIPTION
set gasPrice parametr to fix the Error:
"ProviderError: invalid transaction: insufficient funds for gas * price + value"